### PR TITLE
Added django_init command to auto setup Django project with static & …

### DIFF
--- a/public/mahamudh472/lazy.sh
+++ b/public/mahamudh472/lazy.sh
@@ -1,0 +1,81 @@
+# Create a new Django project with static, templates, and media setup
+
+setup_virtualenv() {
+	# Check if virtual environment already exists
+	if [ -d "venv" ]; then
+		echo "Virtual environment 'venv' already exists. Activating..."
+		return 0
+	fi
+	
+	echo "Virtual environment not found. Creating new one..."
+	
+	if command -v virtualenv >/dev/null 2>&1; then
+		virtualenv venv
+		echo "Virtualenv created using 'virtualenv' package."
+	else
+		echo "The 'virtualenv' package is not installed."
+		read -p "Would you like to install 'virtualenv'? (y/n, default: use python -m venv): " choice
+		if [ "$choice" = "y" ]; then
+			if ! pip install virtualenv; then
+				echo "pip install failed. Trying apt install python3-virtualenv..."
+				sudo apt update && sudo apt install -y python3-virtualenv
+			fi
+			virtualenv venv
+			echo "Virtualenv installed and created."
+			
+		else
+			python3 -m venv venv
+			echo "Virtualenv created using default 'venv' module."
+		fi
+	fi
+}
+
+django_init() {
+	if ! command -v python3 >/dev/null 2>&1; then
+		echo "Python3 is not installed or not found in PATH."
+		return 1
+	fi
+	
+	if [ -z "$1" ]; then
+		echo "Usage: django_init <project_name>"
+		return 1
+	fi
+    
+	PROJECT_NAME=$1
+	mkdir -p $PROJECT_NAME
+	cd $PROJECT_NAME || exit 1
+
+	setup_virtualenv
+	source venv/bin/activate
+	echo "Virtualenv activated."
+
+	
+	if ! command -v django-admin >/dev/null 2>&1; then
+		echo "'django-admin' not found. Installing Django via pip..."
+		pip install django || { echo "Failed to install Django."; return 1; }
+	fi
+	django-admin startproject $PROJECT_NAME .
+
+	# Create directories
+	mkdir -p static
+	mkdir -p templates
+	mkdir -p media
+
+	# Update settings.py
+	SETTINGS_FILE="$PROJECT_NAME/settings.py"
+	if ! grep -q "'django.contrib.staticfiles'" "$SETTINGS_FILE"; then
+		sed -i "/^INSTALLED_APPS = \[/a    'django.contrib.staticfiles'," "$SETTINGS_FILE"
+	fi
+	echo -e "\nSTATICFILES_DIRS = [BASE_DIR / 'static']\nTEMPLATES[0]['DIRS'] = [BASE_DIR / 'templates']\nMEDIA_URL = '/media/'\nMEDIA_ROOT = BASE_DIR / 'media'" >> $SETTINGS_FILE
+
+	echo "Django project '$PROJECT_NAME' created with static, templates, and media directories."
+}
+
+# Usage:
+# django_init myproject
+
+# CLI router
+if [ "$1" = "django_init" ]; then
+	shift
+	django_init "$@"
+fi


### PR DESCRIPTION

## ✨ Added `django_init` Command

### Summary

This PR introduces a new CLI command `django_init` to streamline the setup of a new Django project.
The command automatically:

* Detects or creates a virtual environment (`venv`).
* Installs Django if not already available.
* Creates a Django project with the specified name.
* Sets up **static**, **templates**, and **media** directories.
* Updates `settings.py` with default configurations for static, templates, and media.

### Usage

```bash
lazy django_init <project_name>
```

Example:

```bash
lazy django_init myproject
```

### Features

* ✅ Auto-detects existing virtual environment or creates a new one.
* ✅ Supports both `virtualenv` and default `python -m venv`.
* ✅ Installs Django if not installed.
* ✅ Configures `STATICFILES_DIRS`, `TEMPLATES`, `MEDIA_URL`, and `MEDIA_ROOT` automatically.
* ✅ Saves initial setup time for Django developers.

### Notes

* Tested on Linux (Ubuntu).
* Works best with Python 3.

